### PR TITLE
Add calculator functionality to delta popup text field

### DIFF
--- a/KeepScore/pom.xml
+++ b/KeepScore/pom.xml
@@ -27,6 +27,11 @@
             <version>1.0</version>
             <type>apklib</type>
         </dependency>
+		<dependency>
+			<groupId>de.congrace</groupId>
+			<artifactId>exp4j</artifactId>
+			<version>0.3.11</version>
+		</dependency>
 
 	</dependencies>
 	<build>

--- a/KeepScore/res/layout/delta_popup.xml
+++ b/KeepScore/res/layout/delta_popup.xml
@@ -10,7 +10,8 @@
 
 		<EditText android:id="@android:id/edit" android:layout_width="0px"
 			android:layout_weight="0.2" android:layout_height="wrap_content"
-			android:singleLine="true" android:inputType="numberSigned"
+			android:singleLine="true" android:inputType="numberSigned" android:digits="01234567890-+*/=() "
+			android:imeOptions="actionGo" android:imeActionLabel="@android:string/ok"
 			android:text="0" android:textSize="@dimen/delta_popup_text"/>
 
 		<Button android:id="@android:id/button1" android:layout_width="0px"

--- a/KeepScore/res/values/strings.xml
+++ b/KeepScore/res/values/strings.xml
@@ -286,6 +286,7 @@ LibreOffice, or Google Docs.</string>
     <string name="toast_settings_reset">Settings reset.</string>
     <string name="toast_valid_initial_score">You must enter a valid number.</string>
     <string name="toast_valid_update_delay_values">You must enter a number between 1 and 600.</string>
+    <string name="toast_calc_error">Invalid calculator entry.</string>
 </resources>
 
 


### PR DESCRIPTION
When you open the delta popup (long-press on <kbd>+</kbd>/<kbd>-</kbd>), on larger devices like the Nexus 7, the keyboard shows a set of calculator-like buttons:

![screenshot_2014-02-20-01-12-02](https://f.cloud.github.com/assets/354349/2215623/1e3e1842-99f7-11e3-8f7a-d0cfd028d9a2.png)

This PR puts those buttons to work and allows you to do some basic math inside the dialog.  For example, you can type `37+3+75+3*2-21` into the edit field, and when you press <kbd>=</kbd> (or tap the dialog's OK button), the field is automatically updated with the answer &ndash; in this example, 100.

This is especially useful in games where you must add up an arbitrary number of points that range from 1 to 100 to reach the player's score for the round.

The entered expression is evaluated with [exp4j](http://www.objecthunter.net/exp4j/), and things like order of operations and parentheses are properly respected.

I've also made two other tweaks:
- When you start typing in the input field, the other buttons are hidden and the input field is resized to fill available width.  This makes it easier to see longer expressions.
- I've wired up the soft keyboard's return button to accept the dialog &ndash; I find it's quicker and easier to hit that button than the OK button of the dialog for some reason.
