### PR TITLE
Delta calc: Only hide the +/- buttons when typing an equation

### DIFF
--- a/KeepScore/src/com/nolanlawson/keepscore/helper/DialogHelper.java
+++ b/KeepScore/src/com/nolanlawson/keepscore/helper/DialogHelper.java
@@ -68,7 +68,6 @@ public class DialogHelper {
         // easier
         // deletion
         
-        
         final AlertDialog adlg = new AlertDialog.Builder(context).setCancelable(true)
                 .setTitle(positive ? R.string.title_add : R.string.title_subtract)
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
@@ -144,16 +143,23 @@ public class DialogHelper {
         editText.addTextChangedListener(new TextWatcher() {
 
 			public void afterTextChanged(Editable s) {
-				button1.setVisibility(View.INVISIBLE);
-				button2.setVisibility(View.INVISIBLE);
-				button3.setVisibility(View.INVISIBLE);
-				button4.setVisibility(View.INVISIBLE);
-
-				ViewGroup.LayoutParams lp = editText.getLayoutParams();
-				lp.width = ViewGroup.LayoutParams.FILL_PARENT;
-				editText.setLayoutParams(lp);
+				String val = s.toString();
+				if (val.indexOf('+') >= 0 || // only hide the +/- buttons if we start typing an equation
+					val.indexOf('-') >= 0 ||
+					val.indexOf('*') >= 0 ||
+					val.indexOf('/') >= 0)
+				{
+					button1.setVisibility(View.INVISIBLE);
+					button2.setVisibility(View.INVISIBLE);
+					button3.setVisibility(View.INVISIBLE);
+					button4.setVisibility(View.INVISIBLE);
+	
+					ViewGroup.LayoutParams lp = editText.getLayoutParams();
+					lp.width = ViewGroup.LayoutParams.FILL_PARENT;
+					editText.setLayoutParams(lp);
+				}
 				
-				int eqidx = s.toString().indexOf('=');
+				int eqidx = val.indexOf('=');
 				if (eqidx >= 0) {
 					s.delete(eqidx, eqidx+1);
 					DoCalculation(editText);


### PR DESCRIPTION
This addresses a comment left in a [review](https://play.google.com/store/apps/details?id=com.nolanlawson.keepscore&reviewId=Z3A6QU9xcFRPSGRGb05FVXI3SHlMYlJQVVhReEJhTXlSRzl0SUZEUEtjS0YxeTljT1JnWE0zckdKVDlUdEs2T1NFWVBfaktpcXVfblUwRUZjMlFLMEV2dGc&hl=en).

>  The "pop-up buttons" shouldn't disappear after you press one. You should be able to keep hitting them until you get the value you want. It's a pain only getting to hit them once each time.

With this change, the increment buttons are now only hidden after the user types one of `+-*/` into the text box.
